### PR TITLE
Refactor load tests

### DIFF
--- a/Retro.Net.Tests/Z80/Decode/JumpTests.cs
+++ b/Retro.Net.Tests/Z80/Decode/JumpTests.cs
@@ -33,7 +33,7 @@ namespace Retro.Net.Tests.Z80.Decode
             var literal = Rng.Byte();
             using (var fixture = new DecodeFixture(2, 8, PrimaryOpCode.DJNZ, literal).DoNotHalt().NotOnGameboy())
             {
-                fixture.Expected.OpCode(OpCode.DecrementJumpRelativeIfNonZero).Operands(Operand.d).ByteLiteral(literal);
+                fixture.Expected.OpCode(OpCode.DecrementJumpRelativeIfNonZero).ByteLiteral(literal);
             }
         }
 
@@ -97,7 +97,7 @@ namespace Retro.Net.Tests.Z80.Decode
                     fixture.NotOnGameboy();
                 }
 
-                fixture.Expected.OpCode(OpCode.JumpRelative).Operands(Operand.d).ByteLiteral(literal);
+                fixture.Expected.OpCode(OpCode.JumpRelative).ByteLiteral(literal);
 
                 if (test != FlagTest.None)
                 {

--- a/Retro.Net.Tests/Z80/Decode/OperationFactory.cs
+++ b/Retro.Net.Tests/Z80/Decode/OperationFactory.cs
@@ -54,9 +54,28 @@ namespace Retro.Net.Tests.Z80.Decode
             return this;
         }
 
+        public OperationFactory RandomRegister2(out Operand o)
+        {
+            o = _operand2 = Rng.Pick(Registers);
+            return this;
+        }
+
         public OperationFactory Random16BitRegister(out Operand o)
         {
             o = _operand1 = Rng.Pick(Registers16);
+            return this;
+        }
+
+        public OperationFactory Random16BitRegister2(out Operand o)
+        {
+            o = _operand2 = Rng.Pick(Registers16);
+            return this;
+        }
+
+        public OperationFactory Random16BitRegisters(out Operand o1, out Operand o2)
+        {
+            o1 = _operand1 = Rng.Pick(Registers16);
+            o2 = _operand2 = Rng.Pick(Registers16);
             return this;
         }
 

--- a/Retro.Net.Tests/Z80/Execute/Arithmetic16BitTests.cs
+++ b/Retro.Net.Tests/Z80/Execute/Arithmetic16BitTests.cs
@@ -9,45 +9,37 @@ namespace Retro.Net.Tests.Z80.Execute
 {
     public class Arithmetic16BitTests
     {
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers16Bit), MemberType = typeof(ExecuteFixture))]
-        public void Add16(Operand o) => TestAssign(OpCode.Add16, (alu, o1, o2) => alu.Add(o1, o2), Operand.HL, o);
+        [Fact] public void Add16() => TestAssign(OpCode.Add16, (alu, o1, o2) => alu.Add(o1, o2));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers16Bit), MemberType = typeof(ExecuteFixture))]
-        public void AddWithCarry16(Operand o) => TestAssign(OpCode.AddWithCarry16, (alu, o1, o2) => alu.AddWithCarry(o1, o2), Operand.HL, o);
+        [Fact] public void AddWithCarry16() => TestAssign(OpCode.AddWithCarry16, (alu, o1, o2) => alu.AddWithCarry(o1, o2));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers16Bit), MemberType = typeof(ExecuteFixture))]
-        public void SubtractWithCarry16(Operand o) => TestAssign(OpCode.SubtractWithCarry16, (alu, o1, o2) => alu.SubtractWithCarry(o1, o2), Operand.HL, o);
+        [Fact] public void SubtractWithCarry16() => TestAssign(OpCode.SubtractWithCarry16, (alu, o1, o2) => alu.SubtractWithCarry(o1, o2));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers16Bit), MemberType = typeof(ExecuteFixture))]
-        public void Increment16(Operand o)
+        [Fact]
+        public void Increment16()
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(OpCode.Increment16).Operands(o);
+                fixture.Operation.OpCode(OpCode.Increment16).Random16BitRegister(out var o);
                 fixture.Assert(c => c.Operand16(o).ShouldBe(unchecked ((ushort) (c.InitialRegister16(o) + 1))));
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers16Bit), MemberType = typeof(ExecuteFixture))]
-        public void Decrement16(Operand o)
+        [Fact]
+        public void Decrement16()
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(OpCode.Decrement16).Operands(o);
-                fixture.Assert(c => c.Operand16(o).ShouldBe(unchecked((ushort)(c.InitialRegister16(o) - 1))));
+                fixture.Operation.OpCode(OpCode.Decrement16).Random16BitRegister(out var o);
+                fixture.Assert(c => c.Operand16(o).ShouldBe(unchecked((ushort) (c.InitialRegister16(o) - 1))));
             }
         }
 
-        private static void TestAssign(OpCode op, Expression<Func<IAlu, ushort, ushort, ushort>> f, Operand o1, Operand? o2 = null)
+        private static void TestAssign(OpCode op, Expression<Func<IAlu, ushort, ushort, ushort>> f)
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(op).Operands(o1, o2);
+                fixture.Operation.OpCode(op).Random16BitRegisters(out var o1, out var o2);
                 fixture.With(c => c.Alu.Setup(c.Alu16Call(f, o1, o2)).Returns(c.Word).Verifiable());
                 fixture.Assert(c => c.Operand16(o1).ShouldBe(c.Word));
             }

--- a/Retro.Net.Tests/Z80/Execute/Arithmetic8BitTests.cs
+++ b/Retro.Net.Tests/Z80/Execute/Arithmetic8BitTests.cs
@@ -9,71 +9,51 @@ namespace Retro.Net.Tests.Z80.Execute
 {
     public class Arithmetic8BitTests
     {
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Add(Operand o) => TestAccumulatorAssign(OpCode.Add, o, (alu, o0, o1) => alu.Add(o0, o1));
+        [Fact] public void Add() => TestAccumulatorAssign(OpCode.Add, (alu, o0, o1) => alu.Add(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void AddCarry(Operand o) => TestAccumulatorAssign(OpCode.AddWithCarry, o, (alu, o0, o1) => alu.AddWithCarry(o0, o1));
+        [Fact] public void AddCarry() => TestAccumulatorAssign(OpCode.AddWithCarry, (alu, o0, o1) => alu.AddWithCarry(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Subtract(Operand o) => TestAccumulatorAssign(OpCode.Subtract, o, (alu, o0, o1) => alu.Subtract(o0, o1));
+        [Fact] public void Subtract() => TestAccumulatorAssign(OpCode.Subtract, (alu, o0, o1) => alu.Subtract(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void SubtractCarry(Operand o) => TestAccumulatorAssign(OpCode.SubtractWithCarry, o, (alu, o0, o1) => alu.SubtractWithCarry(o0, o1));
+        [Fact] public void SubtractCarry() => TestAccumulatorAssign(OpCode.SubtractWithCarry, (alu, o0, o1) => alu.SubtractWithCarry(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void And(Operand o) => TestAccumulatorAssign(OpCode.And, o, (alu, o0, o1) => alu.And(o0, o1));
+        [Fact] public void And() => TestAccumulatorAssign(OpCode.And, (alu, o0, o1) => alu.And(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Or(Operand o) => TestAccumulatorAssign(OpCode.Or, o, (alu, o0, o1) => alu.Or(o0, o1));
+        [Fact] public void Or() => TestAccumulatorAssign(OpCode.Or, (alu, o0, o1) => alu.Or(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Xor(Operand o) => TestAccumulatorAssign(OpCode.Xor, o, (alu, o0, o1) => alu.Xor(o0, o1));
+        [Fact] public void Xor() => TestAccumulatorAssign(OpCode.Xor, (alu, o0, o1) => alu.Xor(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Compare(Operand o) => TestCall(OpCode.Compare, o, (alu, o0, o1) => alu.Compare(o0, o1));
+        [Fact] public void Compare() => TestCall(OpCode.Compare, (alu, o0, o1) => alu.Compare(o0, o1));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Increment(Operand o) => TestCallAssign(OpCode.Increment, o, (alu, o0) => alu.Increment(o0));
+        [Fact] public void Increment() => TestCallAssign(OpCode.Increment, (alu, o0) => alu.Increment(o0));
 
-        [Theory]
-        [MemberData(nameof(ExecuteFixture.Registers8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Decrement(Operand o) => TestCallAssign(OpCode.Decrement, o, (alu, o0) => alu.Decrement(o0));
+        [Fact] public void Decrement() => TestCallAssign(OpCode.Decrement, (alu, o0) => alu.Decrement(o0));
         
-        private static void TestAccumulatorAssign(OpCode op, Operand o, Expression<Func<IAlu, byte, byte, byte>> f)
+        private static void TestAccumulatorAssign(OpCode op, Expression<Func<IAlu, byte, byte, byte>> f)
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(op).Operands(o).RandomLiterals();
+                fixture.Operation.OpCode(op).RandomRegister(out var o).RandomLiterals();
                 fixture.With(c => c.Alu.Setup(c.Alu8Call(f, Operand.A, o)).Returns(c.Byte).Verifiable());
                 fixture.Assert(c => c.Accumulator.A.ShouldBe(c.Byte));
             }
         }
 
-        private static void TestCallAssign(OpCode op, Operand o, Expression<Func<IAlu, byte, byte>> f)
+        private static void TestCallAssign(OpCode op, Expression<Func<IAlu, byte, byte>> f)
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(op).Operands(o).RandomLiterals();
+                fixture.Operation.OpCode(op).RandomRegister(out var o).RandomLiterals();
                 fixture.With(c => c.Alu.Setup(c.Alu8Call(f, o)).Returns(c.Byte).Verifiable());
                 fixture.Assert(c => c.Operand8(o).ShouldBe(c.Byte));
             }
         }
 
-        private static void TestCall(OpCode op, Operand o, Expression<Action<IAlu, byte, byte>> f)
+        private static void TestCall(OpCode op, Expression<Action<IAlu, byte, byte>> f)
         {
             using (var fixture = new ExecuteFixture())
             {
-                fixture.Operation.OpCode(op).Operands(o).RandomLiterals();
+                fixture.Operation.OpCode(op).RandomRegister(out var o).RandomLiterals();
                 fixture.With(c => c.Alu.Setup(c.AluAction(f, Operand.A, o)).Verifiable());
             }
         }

--- a/Retro.Net.Tests/Z80/Execute/CompareTests.cs
+++ b/Retro.Net.Tests/Z80/Execute/CompareTests.cs
@@ -21,8 +21,8 @@ namespace Retro.Net.Tests.Z80.Execute
             using (var fixture = new ExecuteFixture())
             {
                 fixture.Operation.OpCode(op);
-                fixture.With(c => c.Mmu.Setup(x => x.ReadByte(c.Registers.HL)).Returns(c.IndexedByte).Verifiable());
-                fixture.Assert(c => c.Alu.Verify(x => x.Compare(c.Accumulator.A, c.IndexedByte)),
+                fixture.With(c => c.Mmu.Setup(x => x.ReadByte(c.Registers.HL)).Returns(c.Byte).Verifiable());
+                fixture.Assert(c => c.Alu.Verify(x => x.Compare(c.Accumulator.A, c.Byte)),
                     c => c.Registers.BC.ShouldBe(unchecked((ushort) (c.InitialRegister16(Operand.BC) - 1))));
 
                 if (decrement)

--- a/Retro.Net.Tests/Z80/Execute/ExecuteFixture.cs
+++ b/Retro.Net.Tests/Z80/Execute/ExecuteFixture.cs
@@ -133,16 +133,5 @@ namespace Retro.Net.Tests.Z80.Execute
         }
 
         public void Dispose() => "All cores".ShouldSatisfyAllConditions("", Test<DynaRec>, Test<Interpreter>);
-
-        public static IEnumerable<object[]> Registers8Bit() =>
-            new SimpleTheorySource<Operand>(Operand.A, Operand.B, Operand.C, Operand.D, Operand.E, Operand.H, Operand.L);
-
-        public static IEnumerable<object[]> Registers16Bit() => new SimpleTheorySource<Operand>(Operand.AF, Operand.BC, Operand.DE, Operand.HL, Operand.IX, Operand.IY);
-        
-        public static IEnumerable<object[]> Operands8Bit() =>
-            new SimpleTheorySource<Operand>(Operand.A, Operand.B, Operand.C, Operand.D, Operand.E, Operand.H, Operand.L, Operand.n, Operand.mHL, Operand.mIXd, Operand.mIYd, Operand.mnn);
-
-        public static IEnumerable<object[]> Operands16Bit() =>
-            new SimpleTheorySource<Operand>(Operand.AF, Operand.BC, Operand.DE, Operand.HL, Operand.IX, Operand.IY, Operand.nn);
     }
 }

--- a/Retro.Net.Tests/Z80/Execute/ExecutionContext.cs
+++ b/Retro.Net.Tests/Z80/Execute/ExecutionContext.cs
@@ -53,27 +53,7 @@ namespace Retro.Net.Tests.Z80.Execute
             MockRegisters.Object.ProgramCounter = InitialProgramCounter = Rng.Word();
             MockRegisters.Setup(x => x.GeneralPurposeRegisters).Returns(registers);
             MockRegisters.Setup(x => x.AccumulatorAndFlagsRegisters).Returns(accumulator);
-
-            if (Operation.Operand1 == Operand.mHL || Operation.Operand2 == Operand.mHL)
-            {
-                Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == registers.HL))).Returns(IndexedByte).Verifiable();
-            }
-
-            if (Operation.Operand1 == Operand.mIXd || Operation.Operand2 == Operand.mIXd)
-            {
-                Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == MockRegisters.Object.IX + operation.Displacement))).Returns(IndexedXByte).Verifiable();
-            }
-
-            if (Operation.Operand1 == Operand.mIYd || Operation.Operand2 == Operand.mIYd)
-            {
-                Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == MockRegisters.Object.IY + operation.Displacement))).Returns(IndexedYByte).Verifiable();
-            }
-
-            if (Operation.Operand1 == Operand.mnn || Operation.Operand2 == Operand.mnn)
-            {
-                Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == Operation.WordLiteral))).Returns(LiteralIndexedByte).Verifiable();
-            }
-
+            
             // Don't want the initialization calls hanging around for verification.
             Flags.ResetCalls(); 
             MockRegisters.ResetCalls();
@@ -114,15 +94,7 @@ namespace Retro.Net.Tests.Z80.Execute
         public ushort ProgramCounter => MockRegisters.Object.ProgramCounter;
 
         public ushort StackPointer => MockRegisters.Object.StackPointer;
-
-        public byte LiteralIndexedByte { get; } = Rng.Byte();
-
-        public byte IndexedByte { get; } = Rng.Byte();
-
-        public byte IndexedXByte { get; } = Rng.Byte();
-
-        public byte IndexedYByte { get; } = Rng.Byte();
-
+        
         public byte Byte { get; } = Rng.Byte();
 
         public ushort Word { get; } = Rng.Word();
@@ -198,6 +170,7 @@ namespace Retro.Net.Tests.Z80.Execute
                     return Registers.H;
                 case Operand.L:
                     return Registers.L;
+
                 case Operand.IXl:
                     return MockRegisters.Object.IXl;
                 case Operand.IYl:
@@ -207,16 +180,13 @@ namespace Retro.Net.Tests.Z80.Execute
                 case Operand.IYh:
                     return MockRegisters.Object.IYh;
 
+                case Operand.I:
+                    return MockRegisters.Object.I;
+                case Operand.R:
+                    return MockRegisters.Object.R;
+                    
                 case Operand.n:
                     return Operation.ByteLiteral;
-                case Operand.mnn:
-                    return LiteralIndexedByte;
-                case Operand.mHL:
-                    return IndexedByte;
-                case Operand.mIXd:
-                    return IndexedXByte;
-                case Operand.mIYd:
-                    return IndexedYByte;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(r), r, "Must be an 8-bit operand");
@@ -245,6 +215,8 @@ namespace Retro.Net.Tests.Z80.Execute
 
                 case Operand.nn:
                     return Operation.WordLiteral;
+                case Operand.SPd:
+                    return (ushort) (MockRegisters.Object.StackPointer + Operation.Displacement);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(r), r, "Must be an 16-bit operand");

--- a/Retro.Net.Tests/Z80/Execute/LoadTests.cs
+++ b/Retro.Net.Tests/Z80/Execute/LoadTests.cs
@@ -1,31 +1,177 @@
-﻿using Retro.Net.Z80.Core.Decode;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Retro.Net.Tests.Util;
+using Retro.Net.Z80.Core.Decode;
 using Shouldly;
 using Xunit;
 
 namespace Retro.Net.Tests.Z80.Execute
 {
+    /// <summary>
+    /// Tests load function and reading & wriitng of all operands.
+    /// </summary>
     public class LoadTests
     {
+        private static readonly Operand[] Writable8BitOperands =
+        {
+            Operand.A, Operand.B, Operand.C, Operand.D, Operand.E, Operand.F, Operand.H, Operand.L,
+            Operand.mHL, Operand.mIXd, Operand.mIYd, Operand.IXl, Operand.IXh, Operand.IYl, Operand.IYh, Operand.I,
+            Operand.mnn, Operand.mCl, Operand.mnl, Operand.mBC, Operand.mDE, Operand.mSP
+        };
+
+        private static readonly Operand[] Writable16BitOperands = { Operand.AF, Operand.BC, Operand.DE, Operand.HL, Operand.IX, Operand.IY };
+
         [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands8Bit), MemberType = typeof(ExecuteFixture))]
-        public void Load(Operand r)
+        [MemberData(nameof(Readable8Bit))]
+        public void When_reading_8bit_operands(Operand r)
         {
             using (var fixture = new ExecuteFixture())
             {
                 fixture.Operation.OpCode(OpCode.Load).RandomRegister(out var o).Operand2(r).RandomLiterals();
-                fixture.Assert(c => c.Operand8(o).ShouldBe(c.Operand8(r)));
+
+                var value = Rng.Byte();
+                fixture.With(c =>
+                {
+                    switch (c.Operation.Operand2)
+                    {
+                        case Operand.mHL:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Registers.HL))).Returns(value).Verifiable();
+                            break;
+
+                        case Operand.mIXd:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.MockRegisters.Object.IX + c.Operation.Displacement))).Returns(value).Verifiable();
+                            break;
+                        case Operand.mIYd:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.MockRegisters.Object.IY + c.Operation.Displacement))).Returns(value).Verifiable();
+                            break;
+
+                        case Operand.mnn:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Operation.WordLiteral))).Returns(value).Verifiable();
+                            break;
+
+                        case Operand.mCl:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Registers.C + 0xff00))).Returns(value).Verifiable();
+                            break;
+                        case Operand.mnl:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Operation.ByteLiteral + 0xff00))).Returns(value).Verifiable();
+                            break;
+
+                        case Operand.mBC:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Registers.BC))).Returns(value).Verifiable();
+                            break;
+                        case Operand.mDE:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.Registers.DE))).Returns(value).Verifiable();
+                            break;
+                        case Operand.mSP:
+                            c.Mmu.Setup(m => m.ReadByte(It.Is<ushort>(a => a == c.MockRegisters.Object.StackPointer))).Returns(value).Verifiable();
+                            break;
+
+                        default:
+                            value = c.Operand8(c.Operation.Operand2);
+                            break;
+                    }
+                });
+                fixture.Assert(c => c.Operand8(o).ShouldBe(value));
             }
         }
 
         [Theory]
-        [MemberData(nameof(ExecuteFixture.Operands16Bit), MemberType = typeof(ExecuteFixture))]
-        public void Load16(Operand r)
+        [MemberData(nameof(Writable8Bit))]
+        public void When_writing_8bit_operands(Operand r)
+        {
+            using (var fixture = new ExecuteFixture())
+            {
+                fixture.Operation.OpCode(OpCode.Load).Operands(r).RandomRegister2(out var o).RandomLiterals();
+                fixture.Assert(c =>
+                {
+                    var value = c.Operand8(c.Operation.Operand2);
+                    switch (c.Operation.Operand1)
+                    {
+                        case Operand.mHL:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Registers.HL), value));
+                            break;
+
+                        case Operand.mIXd:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.MockRegisters.Object.IX + c.Operation.Displacement), value));
+                            break;
+                        case Operand.mIYd:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.MockRegisters.Object.IY + c.Operation.Displacement), value));
+                            break;
+
+                        case Operand.mnn:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Operation.WordLiteral), value));
+                            break;
+
+                        case Operand.mCl:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Registers.C + 0xff00), value));
+                            break;
+                        case Operand.mnl:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Operation.ByteLiteral + 0xff00), value));
+                            break;
+
+                        case Operand.mBC:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Registers.BC), value));
+                            break;
+                        case Operand.mDE:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.Registers.DE), value));
+                            break;
+                        case Operand.mSP:
+                            c.Mmu.Verify(m => m.WriteByte(It.Is<ushort>(a => a == c.MockRegisters.Object.StackPointer), value));
+                            break;
+                            
+                        default:
+                            c.Operand8(c.Operation.Operand1).ShouldBe(value);
+                            break;
+                    }
+                });
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Readable16Bit))]
+        public void When_reading_16bit_operands(Operand r)
         {
             using (var fixture = new ExecuteFixture())
             {
                 fixture.Operation.OpCode(OpCode.Load16).Random16BitRegister(out var o).Operand2(r).RandomLiterals();
-                fixture.Assert(c => c.Operand16(o).ShouldBe(c.Operand16(r)));
+
+                var value = Rng.Word();
+                fixture.With(c =>
+                {
+                    if (r == Operand.SPd)
+                    {
+                        c.Alu.Setup(a => a.AddDisplacement(c.MockRegisters.Object.StackPointer, c.Operation.Displacement)).Returns(value);
+                    }
+                    else
+                    {
+                        value = c.Operand16(r);
+                    }
+                });
+
+                fixture.Assert(c => c.Operand16(o).ShouldBe(value));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(Writeble16Bit))]
+        public void When_writing_16bit_operands(Operand r)
+        {
+            using (var fixture = new ExecuteFixture())
+            {
+                fixture.Operation.OpCode(OpCode.Load16).Operands(r).Random16BitRegister2(out var o).RandomLiterals();
+                fixture.Assert(c => c.Operand16(r).ShouldBe(c.Operand16(o)));
+            }
+        }
+
+        private static IEnumerable<object[]> Readable8Bit() =>
+            new SimpleTheorySource<Operand>(Writable8BitOperands.Concat(new[] {Operand.n, Operand.R}).ToArray());
+
+        private static IEnumerable<object[]> Writable8Bit() => new SimpleTheorySource<Operand>(Writable8BitOperands);
+        
+        private static IEnumerable<object[]> Readable16Bit() =>
+            new SimpleTheorySource<Operand>(Writable16BitOperands.Concat(new[] {Operand.nn, Operand.SPd}).ToArray());
+
+        private static IEnumerable<object[]> Writeble16Bit() => new SimpleTheorySource<Operand>(Writable16BitOperands);
     }
 }

--- a/Retro.Net/Z80/Core/Decode/OpCodeDecoder.Primary.cs
+++ b/Retro.Net/Z80/Core/Decode/OpCodeDecoder.Primary.cs
@@ -1116,30 +1116,25 @@ namespace Retro.Net.Z80.Core.Decode
 
                 case PrimaryOpCode.JR:
                     _timer.MmuByte().ApplyDisplacement();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     return OpCode.JumpRelative;
                 case PrimaryOpCode.JR_C:
                     _timer.MmuByte();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     _flagTest = FlagTest.Carry;
                     return OpCode.JumpRelative;
                 case PrimaryOpCode.JR_NC:
                     _timer.MmuByte();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     _flagTest = FlagTest.NotCarry;
                     return OpCode.JumpRelative;
                 case PrimaryOpCode.JR_Z:
                     _timer.MmuByte();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     _flagTest = FlagTest.Zero;
                     return OpCode.JumpRelative;
                 case PrimaryOpCode.JR_NZ:
                     _timer.MmuByte();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     _flagTest = FlagTest.NotZero;
                     return OpCode.JumpRelative;
@@ -1159,7 +1154,6 @@ namespace Retro.Net.Z80.Core.Decode
                     }
 
                     _timer.Extend(1).MmuByte();
-                    _operand1 = Operand.d;
                     _decodeMeta = DecodeMeta.ByteLiteral | DecodeMeta.EndBlock;
                     return OpCode.DecrementJumpRelativeIfNonZero;
 

--- a/Retro.Net/Z80/Core/Decode/Operand.cs
+++ b/Retro.Net/Z80/Core/Decode/Operand.cs
@@ -34,7 +34,6 @@
         mnn,
         nn,
         n,
-        d,
 
         // Z80 indexes
         IX,

--- a/Retro.Net/Z80/Core/Decode/Operation.cs
+++ b/Retro.Net/Z80/Core/Decode/Operation.cs
@@ -212,13 +212,11 @@ namespace Retro.Net.Z80.Core.Decode
                 case Operand.mSP:
                     return "(SP)";
                 case Operand.mnn:
-                    return $"(0x{WordLiteral.ToString("x4")})";
+                    return $"(0x{WordLiteral:x4})";
                 case Operand.nn:
-                    return $"0x{WordLiteral.ToString("x4")}";
+                    return $"0x{WordLiteral:x4}";
                 case Operand.n:
-                    return $"0x{ByteLiteral.ToString("x2")}";
-                case Operand.d:
-                    return ((sbyte) ByteLiteral).ToString();
+                    return $"0x{ByteLiteral:x2}";
                 case Operand.mIXd:
                     return Displacement > 0 ? $"(IX+{Displacement})" : $"(IX{Displacement})";
                 case Operand.mIYd:


### PR DESCRIPTION
- Removed extensive operand testing from all execution tests except load tests.
- Actually testing all operand reading and writing now.
- Removed the stupid displacement argument and hard coded it where used.